### PR TITLE
Refactor: Replace deprecated testthat context() with test_that()

### DIFF
--- a/tests/testthat/test-complex_calculate.R
+++ b/tests/testthat/test-complex_calculate.R
@@ -1,220 +1,221 @@
-context("Complex model calculations and error detection")
-library(testthat)
-library(Rydra)
+test_that("Complex model calculations and error detection", {
+  library(testthat)
+  library(Rydra)
 
-config_path <- file.path("..", "..", "inst", "extdata", "complex_config.yaml")
+  config_path <- file.path("..", "..", "inst", "extdata", "complex_config.yaml")
 
-# 1. All conditionals triggered
-test_that("Correct calculation: age > 40, gender = 1, bmi > 30, smoker = 1", {
-  input_data <- list(age = 55, gender = 1, bmi = 32, smoker = 1)
-  # Transformed data:
-  # age_centered = 55 - 40 = 15
-  # age_squared_centered = 15^2 = 225
-  # bmi_centered = 32 - 25 = 7
-  # gender_dependent: age(55)>40 & gender(1)==1 -> intercepts.gender_male = 0.5
-  # Base score calculation:
-  #   intercept: 2.0
-  #   age_centered term: 0.1 * 15 = 1.5
-  #   age_squared_centered term: -0.01 * 225 = -2.25
-  #   bmi_centered term: 0.2 * 7 = 1.4
-  #   gender_dependent term: 1.5 * 0.5 = 0.75
-  #   base_score = 2.0 + 1.5 - 2.25 + 1.4 + 0.75 = 3.4
-  # Factor sum (apply_factors):
-  #   smoker = 1: path 'coefficients.age_centered' resolves to value 0.1
-  #   gender = 1: path 'intercepts.gender_male' resolves to value 0.5
-  #   factor_coeffs_sum = 0.1 + 0.5 = 0.6
-  # Conditional sum (apply_conditions):
-  #   high_bmi_bonus (bmi(32) > 30 is TRUE): path 'coefficients.bmi_centered' resolves to value 0.2
-  #   age_gender_special (age(55) > 50 & gender(1)==1 is TRUE): path 'intercepts.gender_male' resolves to value 0.5
-  #   conditional_coeffs_sum = 0.2 + 0.5 = 0.7
-  # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
-  #             = 3.4 + 0.6 + 0.7 = 4.7
-  # Output transformation: result * 10 = 4.7 * 10 = 47
-  expected_value <- 47
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  # 1. All conditionals triggered
+  test_that("Correct calculation: age > 40, gender = 1, bmi > 30, smoker = 1", {
+    input_data <- list(age = 55, gender = 1, bmi = 32, smoker = 1)
+    # Transformed data:
+    # age_centered = 55 - 40 = 15
+    # age_squared_centered = 15^2 = 225
+    # bmi_centered = 32 - 25 = 7
+    # gender_dependent: age(55)>40 & gender(1)==1 -> intercepts.gender_male = 0.5
+    # Base score calculation:
+    #   intercept: 2.0
+    #   age_centered term: 0.1 * 15 = 1.5
+    #   age_squared_centered term: -0.01 * 225 = -2.25
+    #   bmi_centered term: 0.2 * 7 = 1.4
+    #   gender_dependent term: 1.5 * 0.5 = 0.75
+    #   base_score = 2.0 + 1.5 - 2.25 + 1.4 + 0.75 = 3.4
+    # Factor sum (apply_factors):
+    #   smoker = 1: path 'coefficients.age_centered' resolves to value 0.1
+    #   gender = 1: path 'intercepts.gender_male' resolves to value 0.5
+    #   factor_coeffs_sum = 0.1 + 0.5 = 0.6
+    # Conditional sum (apply_conditions):
+    #   high_bmi_bonus (bmi(32) > 30 is TRUE): path 'coefficients.bmi_centered' resolves to value 0.2
+    #   age_gender_special (age(55) > 50 & gender(1)==1 is TRUE): path 'intercepts.gender_male' resolves to value 0.5
+    #   conditional_coeffs_sum = 0.2 + 0.5 = 0.7
+    # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
+    #             = 3.4 + 0.6 + 0.7 = 4.7
+    # Output transformation: result * 10 = 4.7 * 10 = 47
+    expected_value <- 47
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-# 2. Else branch, no (bmi/age-gender) conditions triggered
-test_that("Correct calculation: age <= 40, gender = 0, bmi = 24, smoker = 0", {
-  input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
-  # Transformed data:
-  # age_centered = 35 - 40 = -5
-  # age_squared_centered = (-5)^2 = 25
-  # bmi_centered = 24 - 25 = -1
-  # gender_dependent: age(35)<=40 -> age_squared_centered + bmi_centered = 25 + (-1) = 24
-  # Base score calculation:
-  #   intercept: 2.0
-  #   age_centered term: 0.1 * (-5) = -0.5
-  #   age_squared_centered term: -0.01 * 25 = -0.25
-  #   bmi_centered term: 0.2 * (-1) = -0.2
-  #   gender_dependent term: 1.5 * 24 = 36.0
-  #   base_score = 2.0 - 0.5 - 0.25 - 0.2 + 36.0 = 37.05
-  # Factor sum (apply_factors):
-  #   smoker = 0: path 'intercepts.baseline' resolves to value 2.0
-  #   gender = 0: path 'intercepts.gender_female' resolves to value -0.3
-  #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
-  # Conditional sum (apply_conditions):
-  #   high_bmi_bonus (bmi(24) > 30 is FALSE)
-  #   age_gender_special (age(35) > 50 is FALSE)
-  #   conditional_coeffs_sum = 0
-  # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
-  #             = 37.05 + 1.7 + 0 = 38.75
-  # Output transformation: result * 10 = 38.75 * 10 = 387.5
-  expected_value <- 387.5
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  # 2. Else branch, no (bmi/age-gender) conditions triggered
+  test_that("Correct calculation: age <= 40, gender = 0, bmi = 24, smoker = 0", {
+    input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
+    # Transformed data:
+    # age_centered = 35 - 40 = -5
+    # age_squared_centered = (-5)^2 = 25
+    # bmi_centered = 24 - 25 = -1
+    # gender_dependent: age(35)<=40 -> age_squared_centered + bmi_centered = 25 + (-1) = 24
+    # Base score calculation:
+    #   intercept: 2.0
+    #   age_centered term: 0.1 * (-5) = -0.5
+    #   age_squared_centered term: -0.01 * 25 = -0.25
+    #   bmi_centered term: 0.2 * (-1) = -0.2
+    #   gender_dependent term: 1.5 * 24 = 36.0
+    #   base_score = 2.0 - 0.5 - 0.25 - 0.2 + 36.0 = 37.05
+    # Factor sum (apply_factors):
+    #   smoker = 0: path 'intercepts.baseline' resolves to value 2.0
+    #   gender = 0: path 'intercepts.gender_female' resolves to value -0.3
+    #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
+    # Conditional sum (apply_conditions):
+    #   high_bmi_bonus (bmi(24) > 30 is FALSE)
+    #   age_gender_special (age(35) > 50 is FALSE)
+    #   conditional_coeffs_sum = 0
+    # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
+    #             = 37.05 + 1.7 + 0 = 38.75
+    # Output transformation: result * 10 = 38.75 * 10 = 387.5
+    expected_value <- 387.5
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-# 3. Error: missing required factor in data
-test_that("Error: missing required factor in data", {
-  input_data <- list(age = 35, gender = 0, bmi = 24) # smoker missing
-  expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
-               "Input data is missing factor: 'smoker'")
-})
+  # 3. Error: missing required factor in data
+  test_that("Error: missing required factor in data", {
+    input_data <- list(age = 35, gender = 0, bmi = 24) # smoker missing
+    expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
+                 "Input data is missing factor: 'smoker'")
+  })
 
-# 4. Error: invalid factor level in data
-test_that("Error: invalid factor level in data", {
-  input_data <- list(age = 35, gender = 2, bmi = 24, smoker = 0) # gender=2 invalid
-  expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
-               "Value '2' for factor 'gender' in input data is not a defined level")
-})
+  # 4. Error: invalid factor level in data
+  test_that("Error: invalid factor level in data", {
+    input_data <- list(age = 35, gender = 2, bmi = 24, smoker = 0) # gender=2 invalid
+    expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
+                 "Value '2' for factor 'gender' in input data is not a defined level")
+  })
 
-# 5. Error: config with missing 'coefficient' in a condition
-test_that("Error: config with missing 'coefficient' in a condition", {
-  input_data <- list(age = -1, gender = 0, bmi = 24, smoker = 0)
-  expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
-               "Condition item #3 is invalid. It must be a list with 'name', 'condition', and 'coefficient' keys.")
-})
+  # 5. Error: config with missing 'coefficient' in a condition
+  test_that("Error: config with missing 'coefficient' in a condition", {
+    input_data <- list(age = -1, gender = 0, bmi = 24, smoker = 0)
+    expect_error(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
+                 "Condition item #3 is invalid. It must be a list with 'name', 'condition', and 'coefficient' keys.")
+  })
 
-# 6. Error: config with coefficient that has no corresponding transformation
-test_that("Error: config with coefficient that has no corresponding transformation", {
-  input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
-  # missing_var is in coefficients but not in data or transformations
-  expect_warning(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
-                 "Coefficient 'missing_var' found, but corresponding data is missing")
-})
+  # 6. Error: config with coefficient that has no corresponding transformation
+  test_that("Error: config with coefficient that has no corresponding transformation", {
+    input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
+    # missing_var is in coefficients but not in data or transformations
+    expect_warning(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"),
+                   "Coefficient 'missing_var' found, but corresponding data is missing")
+  })
 
-# 7. Edge case: age = 40 (boundary)
-test_that("Edge case: age = 40 (boundary)", {
-  input_data <- list(age = 40, gender = 1, bmi = 25, smoker = 1)
-  # Transformed data:
-  # age_centered = 0, age_squared_centered = 0, bmi_centered = 0
-  # gender_dependent: age(40)<=40 -> age_squared_centered + bmi_centered = 0 + 0 = 0
-  # Base score:
-  #   intercept: 2.0
-  #   age_centered term: 0.1 * 0 = 0
-  #   age_squared_centered term: -0.01 * 0 = 0
-  #   bmi_centered term: 0.2 * 0 = 0
-  #   gender_dependent term: 1.5 * 0 = 0
-  #   base_score = 2.0
-  # Factor sum (apply_factors):
-  #   smoker = 1: path 'coefficients.age_centered' resolves to value 0.1
-  #   gender = 1: path 'intercepts.gender_male' resolves to value 0.5
-  #   factor_coeffs_sum = 0.1 + 0.5 = 0.6
-  # Conditional sum (apply_conditions):
-  #   high_bmi_bonus (bmi(25) > 30 is FALSE)
-  #   age_gender_special (age(40) > 50 is FALSE)
-  #   conditional_coeffs_sum = 0
-  # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
-  #             = 2.0 + 0.6 + 0 = 2.6
-  # Output transformation: result * 10 = 2.6 * 10 = 26
-  expected_value <- 26
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  # 7. Edge case: age = 40 (boundary)
+  test_that("Edge case: age = 40 (boundary)", {
+    input_data <- list(age = 40, gender = 1, bmi = 25, smoker = 1)
+    # Transformed data:
+    # age_centered = 0, age_squared_centered = 0, bmi_centered = 0
+    # gender_dependent: age(40)<=40 -> age_squared_centered + bmi_centered = 0 + 0 = 0
+    # Base score:
+    #   intercept: 2.0
+    #   age_centered term: 0.1 * 0 = 0
+    #   age_squared_centered term: -0.01 * 0 = 0
+    #   bmi_centered term: 0.2 * 0 = 0
+    #   gender_dependent term: 1.5 * 0 = 0
+    #   base_score = 2.0
+    # Factor sum (apply_factors):
+    #   smoker = 1: path 'coefficients.age_centered' resolves to value 0.1
+    #   gender = 1: path 'intercepts.gender_male' resolves to value 0.5
+    #   factor_coeffs_sum = 0.1 + 0.5 = 0.6
+    # Conditional sum (apply_conditions):
+    #   high_bmi_bonus (bmi(25) > 30 is FALSE)
+    #   age_gender_special (age(40) > 50 is FALSE)
+    #   conditional_coeffs_sum = 0
+    # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
+    #             = 2.0 + 0.6 + 0 = 2.6
+    # Output transformation: result * 10 = 2.6 * 10 = 26
+    expected_value <- 26
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-# 8. Edge case: bmi = 30 (boundary) - This test calculation aligns with current logic
-test_that("Edge case: bmi = 30 (boundary)", {
-  input_data <- list(age = 45, gender = 0, bmi = 30, smoker = 0)
-  # Transformed data:
-  # age_centered = 5, age_squared_centered = 25, bmi_centered = 5
-  # gender_dependent: age(45)>40 & gender(0)==0 -> intercepts.gender_female = -0.3
-  # Base score:
-  #   intercept: 2.0
-  #   age_centered term: 0.1 * 5 = 0.5
-  #   age_squared_centered term: -0.01 * 25 = -0.25
-  #   bmi_centered term: 0.2 * 5 = 1.0
-  #   gender_dependent term: 1.5 * (-0.3) = -0.45
-  #   base_score = 2.0 + 0.5 - 0.25 + 1.0 - 0.45 = 2.8
-  # Factor sum (apply_factors):
-  #   smoker = 0: path 'intercepts.baseline' resolves to value 2.0
-  #   gender = 0: path 'intercepts.gender_female' resolves to value -0.3
-  #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
-  # Conditional sum (apply_conditions):
-  #   high_bmi_bonus (bmi(30) > 30 is FALSE)
-  #   age_gender_special (age(45) > 50 is FALSE)
-  #   conditional_coeffs_sum = 0
-  # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
-  #             = 2.8 + 1.7 + 0 = 4.5
-  # Output transformation: result * 10 = 4.5 * 10 = 45
-  expected_value <- 45
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  # 8. Edge case: bmi = 30 (boundary) - This test calculation aligns with current logic
+  test_that("Edge case: bmi = 30 (boundary)", {
+    input_data <- list(age = 45, gender = 0, bmi = 30, smoker = 0)
+    # Transformed data:
+    # age_centered = 5, age_squared_centered = 25, bmi_centered = 5
+    # gender_dependent: age(45)>40 & gender(0)==0 -> intercepts.gender_female = -0.3
+    # Base score:
+    #   intercept: 2.0
+    #   age_centered term: 0.1 * 5 = 0.5
+    #   age_squared_centered term: -0.01 * 25 = -0.25
+    #   bmi_centered term: 0.2 * 5 = 1.0
+    #   gender_dependent term: 1.5 * (-0.3) = -0.45
+    #   base_score = 2.0 + 0.5 - 0.25 + 1.0 - 0.45 = 2.8
+    # Factor sum (apply_factors):
+    #   smoker = 0: path 'intercepts.baseline' resolves to value 2.0
+    #   gender = 0: path 'intercepts.gender_female' resolves to value -0.3
+    #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
+    # Conditional sum (apply_conditions):
+    #   high_bmi_bonus (bmi(30) > 30 is FALSE)
+    #   age_gender_special (age(45) > 50 is FALSE)
+    #   conditional_coeffs_sum = 0
+    # Total score = base_score + factor_coeffs_sum + conditional_coeffs_sum
+    #             = 2.8 + 1.7 + 0 = 4.5
+    # Output transformation: result * 10 = 4.5 * 10 = 45
+    expected_value <- 45
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-# 9. Error: missing required config key
-test_that("Error: missing required config key", {
-  # Remove 'output_transformation' from config for this test (simulate by editing in-memory)
-  config <- yaml::read_yaml(config_path)
-  config$complex_model$output_transformation <- NULL
-  input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
-  expect_error(validate_config(config, "complex_model", input_data),
-               "Missing required key in 'complex_model' block: 'output_transformation'")
-})
+  # 9. Error: missing required config key
+  test_that("Error: missing required config key", {
+    # Remove 'output_transformation' from config for this test (simulate by editing in-memory)
+    config <- yaml::read_yaml(config_path)
+    config$complex_model$output_transformation <- NULL
+    input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
+    expect_error(validate_config(config, "complex_model", input_data),
+                 "Missing required key in 'complex_model' block: 'output_transformation'")
+  })
 
-# --- Tests focusing on specific conditions from complex_config.yaml ---
+  # --- Tests focusing on specific conditions from complex_config.yaml ---
 
-test_that("Condition 'high_bmi_bonus' is applied correctly when met", {
-  input_data <- list(age = 45, gender = 0, bmi = 32, smoker = 0) # bmi > 30 is TRUE, age > 50 is FALSE
-  # Transformed data:
-  # age_centered = 5, age_sq_c = 25, bmi_centered = 7
-  # gender_dependent: age(45)>40 & gender(0)==0 -> intercepts.gender_female = -0.3
-  # Base score:
-  #   intercept: 2.0
-  #   age_c: 0.1*5=0.5, age_sq_c: -0.01*25=-0.25, bmi_c: 0.2*7=1.4, gender_dep: 1.5*(-0.3)=-0.45
-  #   base_score = 2.0 + 0.5 - 0.25 + 1.4 - 0.45 = 3.2
-  # Factor sum:
-  #   smoker=0 -> intercepts.baseline (2.0)
-  #   gender=0 -> intercepts.gender_female (-0.3)
-  #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
-  # Conditional sum:
-  #   high_bmi_bonus (TRUE): path 'coefficients.bmi_centered' -> 0.2
-  #   age_gender_special (FALSE for age)
-  #   conditional_coeffs_sum = 0.2
-  # Total score = 3.2 + 1.7 + 0.2 = 5.1
-  # Output = 5.1 * 10 = 51
-  expected_value <- 51
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  test_that("Condition 'high_bmi_bonus' is applied correctly when met", {
+    input_data <- list(age = 45, gender = 0, bmi = 32, smoker = 0) # bmi > 30 is TRUE, age > 50 is FALSE
+    # Transformed data:
+    # age_centered = 5, age_sq_c = 25, bmi_centered = 7
+    # gender_dependent: age(45)>40 & gender(0)==0 -> intercepts.gender_female = -0.3
+    # Base score:
+    #   intercept: 2.0
+    #   age_c: 0.1*5=0.5, age_sq_c: -0.01*25=-0.25, bmi_c: 0.2*7=1.4, gender_dep: 1.5*(-0.3)=-0.45
+    #   base_score = 2.0 + 0.5 - 0.25 + 1.4 - 0.45 = 3.2
+    # Factor sum:
+    #   smoker=0 -> intercepts.baseline (2.0)
+    #   gender=0 -> intercepts.gender_female (-0.3)
+    #   factor_coeffs_sum = 2.0 - 0.3 = 1.7
+    # Conditional sum:
+    #   high_bmi_bonus (TRUE): path 'coefficients.bmi_centered' -> 0.2
+    #   age_gender_special (FALSE for age)
+    #   conditional_coeffs_sum = 0.2
+    # Total score = 3.2 + 1.7 + 0.2 = 5.1
+    # Output = 5.1 * 10 = 51
+    expected_value <- 51
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-test_that("Condition 'age_gender_special' is applied correctly when met", {
-  input_data <- list(age = 55, gender = 1, bmi = 28, smoker = 0) # age > 50 & gender == 1 is TRUE, bmi > 30 is FALSE
-  # Transformed data:
-  # age_centered = 15, age_sq_c = 225, bmi_centered = 3
-  # gender_dependent: age(55)>40 & gender(1)==1 -> intercepts.gender_male = 0.5
-  # Base score:
-  #   intercept: 2.0
-  #   age_c: 0.1*15=1.5, age_sq_c: -0.01*225=-2.25, bmi_c: 0.2*3=0.6, gender_dep: 1.5*0.5=0.75
-  #   base_score = 2.0 + 1.5 - 2.25 + 0.6 + 0.75 = 2.6
-  # Factor sum:
-  #   smoker=0 -> intercepts.baseline (2.0)
-  #   gender=1 -> intercepts.gender_male (0.5)
-  #   factor_coeffs_sum = 2.0 + 0.5 = 2.5
-  # Conditional sum:
-  #   high_bmi_bonus (FALSE for bmi)
-  #   age_gender_special (TRUE): path 'intercepts.gender_male' -> 0.5
-  #   conditional_coeffs_sum = 0.5
-  # Total score = 2.6 + 2.5 + 0.5 = 5.6
-  # Output = 5.6 * 10 = 56
-  expected_value <- 56
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
-})
+  test_that("Condition 'age_gender_special' is applied correctly when met", {
+    input_data <- list(age = 55, gender = 1, bmi = 28, smoker = 0) # age > 50 & gender == 1 is TRUE, bmi > 30 is FALSE
+    # Transformed data:
+    # age_centered = 15, age_sq_c = 225, bmi_centered = 3
+    # gender_dependent: age(55)>40 & gender(1)==1 -> intercepts.gender_male = 0.5
+    # Base score:
+    #   intercept: 2.0
+    #   age_c: 0.1*15=1.5, age_sq_c: -0.01*225=-2.25, bmi_c: 0.2*3=0.6, gender_dep: 1.5*0.5=0.75
+    #   base_score = 2.0 + 1.5 - 2.25 + 0.6 + 0.75 = 2.6
+    # Factor sum:
+    #   smoker=0 -> intercepts.baseline (2.0)
+    #   gender=1 -> intercepts.gender_male (0.5)
+    #   factor_coeffs_sum = 2.0 + 0.5 = 2.5
+    # Conditional sum:
+    #   high_bmi_bonus (FALSE for bmi)
+    #   age_gender_special (TRUE): path 'intercepts.gender_male' -> 0.5
+    #   conditional_coeffs_sum = 0.5
+    # Total score = 2.6 + 2.5 + 0.5 = 5.6
+    # Output = 5.6 * 10 = 56
+    expected_value <- 56
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 
-test_that("No specific conditions met (complex_config)", {
-  # Uses input from test #2 (age <= 40, gender = 0, bmi = 24, smoker = 0)
-  # where conditional_coeffs_sum was already 0.
-  input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
-  # Base score = 37.05
-  # Factor sum = 1.7
-  # Conditional sum = 0
-  # Total = 38.75 -> Output = 387.5
-  expected_value <- 387.5 # This is same as test #2
-  expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  test_that("No specific conditions met (complex_config)", {
+    # Uses input from test #2 (age <= 40, gender = 0, bmi = 24, smoker = 0)
+    # where conditional_coeffs_sum was already 0.
+    input_data <- list(age = 35, gender = 0, bmi = 24, smoker = 0)
+    # Base score = 37.05
+    # Factor sum = 1.7
+    # Conditional sum = 0
+    # Total = 38.75 -> Output = 387.5
+    expected_value <- 387.5 # This is same as test #2
+    expect_equal(Rydra::rydra_calculate(config_path, input_data, model_name = "complex_model"), expected_value, tolerance = 1e-6)
+  })
 })

--- a/tests/testthat/test-factors_conditions.R
+++ b/tests/testthat/test-factors_conditions.R
@@ -1,141 +1,142 @@
-context("Factors and conditionals")
-library(testthat)
-library(Rydra)
+test_that("Factors and conditionals", {
+  library(testthat)
+  library(Rydra)
 
-# --- FACTORS ---
-test_that("apply_factors returns correct coefficient for single factor", {
-  config <- list(
-    test_model = list(
-      factors = list(
-        list(name = "color", levels = list(
-          list(value = "red", coefficient = 1.5),
-          list(value = "blue", coefficient = 2.5)
-        ))
+  # --- FACTORS ---
+  test_that("apply_factors returns correct coefficient for single factor", {
+    config <- list(
+      test_model = list(
+        factors = list(
+          list(name = "color", levels = list(
+            list(value = "red", coefficient = 1.5),
+            list(value = "blue", coefficient = 2.5)
+          ))
+        )
       )
     )
-  )
-  data <- list(color = "blue")
-  expect_equal(apply_factors(config, data, model_name = "test_model"), 2.5)
-})
+    data <- list(color = "blue")
+    expect_equal(apply_factors(config, data, model_name = "test_model"), 2.5)
+  })
 
-test_that("apply_factors returns sum for multiple factors", {
-  config <- list(
-    test_model = list(
-      factors = list(
-        list(name = "color", levels = list(
-          list(value = "red", coefficient = 1),
-          list(value = "blue", coefficient = 2)
-        )),
-        list(name = "shape", levels = list(
-          list(value = "circle", coefficient = 10),
-          list(value = "square", coefficient = 20)
-        ))
+  test_that("apply_factors returns sum for multiple factors", {
+    config <- list(
+      test_model = list(
+        factors = list(
+          list(name = "color", levels = list(
+            list(value = "red", coefficient = 1),
+            list(value = "blue", coefficient = 2)
+          )),
+          list(name = "shape", levels = list(
+            list(value = "circle", coefficient = 10),
+            list(value = "square", coefficient = 20)
+          ))
+        )
       )
     )
-  )
-  data <- list(color = "red", shape = "square")
-  expect_equal(apply_factors(config, data, model_name = "test_model"), 21)
-})
+    data <- list(color = "red", shape = "square")
+    expect_equal(apply_factors(config, data, model_name = "test_model"), 21)
+  })
 
-test_that("apply_factors warns for invalid factor level", {
-  config <- list(
-    test_model = list(
-      factors = list(
-        list(name = "color", levels = list(
-          list(value = "red", coefficient = 1),
-          list(value = "blue", coefficient = 2)
-        ))
+  test_that("apply_factors warns for invalid factor level", {
+    config <- list(
+      test_model = list(
+        factors = list(
+          list(name = "color", levels = list(
+            list(value = "red", coefficient = 1),
+            list(value = "blue", coefficient = 2)
+          ))
+        )
       )
     )
-  )
-  data <- list(color = "green")
-  expect_warning(apply_factors(config, data, model_name = "test_model"),
-                 "Coefficient for factor 'color' level 'green' is invalid or not found")
-})
+    data <- list(color = "green")
+    expect_warning(apply_factors(config, data, model_name = "test_model"),
+                   "Coefficient for factor 'color' level 'green' is invalid or not found")
+  })
 
-test_that("apply_factors returns 0 if no factors defined", {
-  config <- list(test_model = list(factors = NULL))
-  data <- list()
-  expect_equal(apply_factors(config, data, model_name = "test_model"), 0)
-})
+  test_that("apply_factors returns 0 if no factors defined", {
+    config <- list(test_model = list(factors = NULL))
+    data <- list()
+    expect_equal(apply_factors(config, data, model_name = "test_model"), 0)
+  })
 
-# --- CONDITIONS ---
-test_that("apply_conditions applies correct coefficients for met conditions", {
-  config <- list(
-    test_model = list(
-      intercepts = list(bonus = 5),
-      coefficients = list(penalty = -2),
-      conditions = list(
-        list(name = "bonus_if_true", condition = "x > 10", coefficient = "intercepts.bonus"),
-        list(name = "penalty_if_false", condition = "y == 0", coefficient = "coefficients.penalty")
+  # --- CONDITIONS ---
+  test_that("apply_conditions applies correct coefficients for met conditions", {
+    config <- list(
+      test_model = list(
+        intercepts = list(bonus = 5),
+        coefficients = list(penalty = -2),
+        conditions = list(
+          list(name = "bonus_if_true", condition = "x > 10", coefficient = "intercepts.bonus"),
+          list(name = "penalty_if_false", condition = "y == 0", coefficient = "coefficients.penalty")
+        )
       )
     )
-  )
-  data <- list(x = 15, y = 0)
-  # Both conditions met: 5 + (-2) = 3
-  expect_equal(apply_conditions(model_config = config$test_model, data = data), 3)
-})
+    data <- list(x = 15, y = 0)
+    # Both conditions met: 5 + (-2) = 3
+    expect_equal(apply_conditions(model_config = config$test_model, data = data), 3)
+  })
 
-test_that("apply_conditions returns 0 if no conditions met", {
-  config <- list(
-    test_model = list(
-      intercepts = list(bonus = 5),
-      coefficients = list(penalty = -2),
-      conditions = list(
-        list(name = "bonus_if_true", condition = "x > 10", coefficient = "intercepts.bonus"),
-        list(name = "penalty_if_false", condition = "y == 0", coefficient = "coefficients.penalty")
+  test_that("apply_conditions returns 0 if no conditions met", {
+    config <- list(
+      test_model = list(
+        intercepts = list(bonus = 5),
+        coefficients = list(penalty = -2),
+        conditions = list(
+          list(name = "bonus_if_true", condition = "x > 10", coefficient = "intercepts.bonus"),
+          list(name = "penalty_if_false", condition = "y == 0", coefficient = "coefficients.penalty")
+        )
       )
     )
-  )
-  data <- list(x = 5, y = 1)
-  expect_equal(apply_conditions(model_config = config$test_model, data = data), 0)
-})
+    data <- list(x = 5, y = 1)
+    expect_equal(apply_conditions(model_config = config$test_model, data = data), 0)
+  })
 
-test_that("apply_conditions handles malformed condition (missing coefficient)", {
-  config <- list(
-    test_model = list(
-      conditions = list(
-        list(name = "bad", condition = "x > 0")
+  test_that("apply_conditions handles malformed condition (missing coefficient)", {
+    config <- list(
+      test_model = list(
+        conditions = list(
+          list(name = "bad", condition = "x > 0")
+        )
       )
     )
-  )
-  data <- list(x = 1)
-  # The error is a warning in the new function, and it returns sum of valid conditions.
-  # For a single malformed condition, the sum should be 0, and a warning issued.
-  expect_warning(
-    result <- apply_conditions(model_config = config$test_model, data = data),
-    "Condition item #1 in YAML is invalid."
-  )
-  expect_equal(result, 0) # No valid coefficient should be added
-})
+    data <- list(x = 1)
+    # The error is a warning in the new function, and it returns sum of valid conditions.
+    # For a single malformed condition, the sum should be 0, and a warning issued.
+    expect_warning(
+      result <- apply_conditions(model_config = config$test_model, data = data),
+      "Condition item #1 in YAML is invalid."
+    )
+    expect_equal(result, 0) # No valid coefficient should be added
+  })
 
-test_that("apply_conditions returns 0 if no conditions defined", {
-  config <- list(test_model = list(conditions = NULL)) # model_config directly
-  data <- list(x = 1)
-  expect_equal(apply_conditions(model_config = config$test_model, data = data), 0)
-})
+  test_that("apply_conditions returns 0 if no conditions defined", {
+    config <- list(test_model = list(conditions = NULL)) # model_config directly
+    data <- list(x = 1)
+    expect_equal(apply_conditions(model_config = config$test_model, data = data), 0)
+  })
 
-# Test that apply_conditions can access model_config elements (e.g. intercepts) in condition formula
-test_that("apply_conditions allows conditions to reference model_config elements", {
-  config_complex_condition <- list(
-    test_model_cond = list(
-      intercepts = list(age_threshold = 40, bonus_coeff = 5),
-      conditions = list(
-        list(name = "age_bonus",
-             condition = "age > intercepts.age_threshold", # References model_config$intercepts
-             coefficient = "intercepts.bonus_coeff")
+  # Test that apply_conditions can access model_config elements (e.g. intercepts) in condition formula
+  test_that("apply_conditions allows conditions to reference model_config elements", {
+    config_complex_condition <- list(
+      test_model_cond = list(
+        intercepts = list(age_threshold = 40, bonus_coeff = 5),
+        conditions = list(
+          list(name = "age_bonus",
+               condition = "age > intercepts.age_threshold", # References model_config$intercepts
+               coefficient = "intercepts.bonus_coeff")
+        )
       )
     )
-  )
-  data_above_threshold <- list(age = 45)
-  data_below_threshold <- list(age = 35)
+    data_above_threshold <- list(age = 45)
+    data_below_threshold <- list(age = 35)
 
-  expect_equal(
-    apply_conditions(model_config = config_complex_condition$test_model_cond, data = data_above_threshold),
-    5 # age (45) > intercepts.age_threshold (40) is true, apply intercepts.bonus_coeff (5)
-  )
-  expect_equal(
-    apply_conditions(model_config = config_complex_condition$test_model_cond, data = data_below_threshold),
-    0 # age (35) > intercepts.age_threshold (40) is false
-  )
-}) 
+    expect_equal(
+      apply_conditions(model_config = config_complex_condition$test_model_cond, data = data_above_threshold),
+      5 # age (45) > intercepts.age_threshold (40) is true, apply intercepts.bonus_coeff (5)
+    )
+    expect_equal(
+      apply_conditions(model_config = config_complex_condition$test_model_cond, data = data_below_threshold),
+      0 # age (35) > intercepts.age_threshold (40) is false
+    )
+  })
+})

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -1,208 +1,208 @@
-library(testthat)
-library(Rydra) # Ensure Rydra functions are available
-library(jsonlite) # For reading JSON logs
-library(uuid)     # For checking UUID format if necessary
+test_that("Logging functionality in rydra_calculate", {
+  library(testthat)
+  library(Rydra) # Ensure Rydra functions are available
+  library(jsonlite) # For reading JSON logs
+  library(uuid)     # For checking UUID format if necessary
 
-context("Logging functionality in rydra_calculate")
+  # Helper function to create a temporary config file
+  create_temp_config <- function(..., log_settings = NULL, dir = tempdir()) {
+    config_list <- list(...)
+    if (!is.null(log_settings)) {
+      config_list$logging <- log_settings
+    }
 
-# Helper function to create a temporary config file
-create_temp_config <- function(..., log_settings = NULL, dir = tempdir()) {
-  config_list <- list(...)
-  if (!is.null(log_settings)) {
-    config_list$logging <- log_settings
+    # Use a simpler model for logging tests to reduce complexity of main calc
+    if (is.null(config_list$test_log_model)) {
+        config_list$centering <- list(val = 10)
+        config_list$test_log_model <- list(
+          intercepts = list(baseline = 1.0),
+          coefficients = list(val_centered = 0.5),
+          transformations = list(
+            list(name = "val_centered", formula = "center_variable(val, centering.val)")
+          ),
+          output_transformation = "result + 10"
+        )
+    }
+
+    temp_config_file <- tempfile(tmpdir = dir, fileext = ".yaml")
+    yaml::write_yaml(config_list, temp_config_file)
+    return(temp_config_file)
   }
 
-  # Use a simpler model for logging tests to reduce complexity of main calc
-  if (is.null(config_list$test_log_model)) {
-      config_list$centering <- list(val = 10)
-      config_list$test_log_model <- list(
-        intercepts = list(baseline = 1.0),
-        coefficients = list(val_centered = 0.5),
-        transformations = list(
-          list(name = "val_centered", formula = "center_variable(val, centering.val)")
-        ),
-        output_transformation = "result + 10"
-      )
-  }
+  test_that("Logging is disabled by default and no logs are created", {
+    temp_log_dir <- file.path(tempdir(), "default_log_test")
+    # Ensure no pre-existing "rydra_logs" in CWD from other tests or runs
+    if (dir.exists("rydra_logs")) unlink("rydra_logs", recursive = TRUE)
+    # Also clean up temp_log_dir if it exists (it shouldn't for this test's purpose)
+    if (dir.exists(temp_log_dir)) unlink(temp_log_dir, recursive = TRUE)
 
-  temp_config_file <- tempfile(tmpdir = dir, fileext = ".yaml")
-  yaml::write_yaml(config_list, temp_config_file)
-  return(temp_config_file)
-}
+    # Create a config without any logging section
+    config_file <- create_temp_config(dir = temp_log_dir)
 
-test_that("Logging is disabled by default and no logs are created", {
-  temp_log_dir <- file.path(tempdir(), "default_log_test")
-  # Ensure no pre-existing "rydra_logs" in CWD from other tests or runs
+    input_data <- list(val = 15)
+
+    # Run calculation
+    Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
+
+    # Assert that the default "rydra_logs" directory is NOT created in CWD
+    expect_false(dir.exists("rydra_logs"), "Default 'rydra_logs' directory created when logging should be disabled.")
+    # Assert that no log directory was created in the temp_log_dir either (where config was)
+    expect_false(dir.exists(file.path(temp_log_dir, "rydra_logs")), "Default 'rydra_logs' created in temp test dir.")
+
+    # Clean up
+    unlink(config_file, force = TRUE)
+    unlink(temp_log_dir, recursive = TRUE, force = TRUE)
+    if (dir.exists("rydra_logs")) unlink("rydra_logs", recursive = TRUE) # General cleanup
+  })
+
+  test_that("Logging enabled with default path creates logs in 'rydra_logs'", {
+    # Test in a controlled temporary directory to avoid cluttering the project root with "rydra_logs"
+    test_env_dir <- file.path(tempdir(), "test_env_default_log")
+    if (dir.exists(test_env_dir)) unlink(test_env_dir, recursive = TRUE)
+    dir.create(test_env_dir, showWarnings = FALSE, recursive = TRUE)
+
+    original_wd <- getwd()
+    setwd(test_env_dir) # Set WD to ensure 'rydra_logs' is created here if default path logic works as CWD-relative
+
+    default_log_path <- "rydra_logs"
+    if (dir.exists(default_log_path)) unlink(default_log_path, recursive = TRUE) # Clean up before test
+
+    config_file <- create_temp_config(log_settings = list(enabled = TRUE), dir = test_env_dir) # Config in test_env_dir
+
+    input_data <- list(val = 20)
+
+    # Expected values for the simple model:
+    # val_centered = 20 - 10 = 10
+    # base_score = 1.0 (intercept) + (10 * 0.5) (val_centered * coeff) = 1.0 + 5.0 = 6.0
+    # total_score (pre-output) = 6.0
+    # final_result = 6.0 + 10 = 16.0
+    expected_final_result <- 16.0
+
+    result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
+    expect_equal(result, expected_final_result)
+
+    expect_true(dir.exists(default_log_path), "Default 'rydra_logs' directory was not created in the current working directory.")
+
+    log_files <- list.files(default_log_path, pattern = "\\.json$")
+    expect_true(length(log_files) > 0, "No JSON log files found in the default log directory.")
+
+    # Check content of one log file
+    log_content <- jsonlite::read_json(file.path(default_log_path, log_files[1]))
+
+    expect_true(!is.null(log_content$timestamp))
+    expect_equal(log_content$invocation_params$config_path, config_file)
+    expect_equal(log_content$invocation_params$model_name, "test_log_model")
+    expect_equal(log_content$invocation_params$data$val, input_data$val)
+    expect_true(!is.null(log_content$model_config_used))
+    expect_equal(log_content$intermediate_values$transformed_data$val_centered, 10) # (20-10)
+    expect_equal(log_content$final_result, expected_final_result)
+
+    # Filename check: YYYYMMDDHHMMSSxxxxxx_uuid.json
+    expect_true(grepl("^\\d{14}\\d{2,6}_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.json$", log_files[1]))
+
+    # Clean up
+    setwd(original_wd)
+    unlink(test_env_dir, recursive = TRUE, force = TRUE)
+  })
+
+
+  test_that("Logging enabled with a custom path creates logs in that path", {
+    custom_log_dir <- file.path(tempdir(), "custom_rydra_logs")
+    if (dir.exists(custom_log_dir)) unlink(custom_log_dir, recursive = TRUE) # Clean before test
+
+    config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = custom_log_dir))
+
+    input_data <- list(val = 25)
+    expected_final_result <- ((25 - 10) * 0.5 + 1.0) + 10 # 7.5 + 1.0 + 10 = 18.5
+
+    result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
+    expect_equal(result, expected_final_result)
+
+    expect_true(dir.exists(custom_log_dir), "Custom log directory was not created.")
+
+    log_files <- list.files(custom_log_dir, pattern = "\\.json$")
+    expect_true(length(log_files) > 0, "No JSON log files found in the custom log directory.")
+
+    log_content <- jsonlite::read_json(file.path(custom_log_dir, log_files[1]))
+    expect_equal(log_content$final_result, expected_final_result)
+    expect_equal(log_content$invocation_params$data$val, input_data$val)
+
+    # Clean up
+    unlink(config_file, force = TRUE)
+    unlink(custom_log_dir, recursive = TRUE, force = TRUE)
+  })
+
+  test_that("Logging handles non-serializable data gracefully (logs what it can)", {
+    # This test is more about ensuring the main calc doesn't fail if logging has an issue with complex data.
+    # The current implementation converts factors to characters, which is good.
+    # True non-serializable (like environments or connections) would error in jsonlite, caught by tryCatch.
+
+    log_dir <- file.path(tempdir(), "complex_data_log_test")
+    if (dir.exists(log_dir)) unlink(log_dir, recursive = TRUE)
+
+    config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = log_dir))
+
+    # Input data with a factor, which our logger handles by converting to character
+    input_data_complex <- list(val = 30, category = factor("A"))
+
+    # Expected calculation for 'val' part: ((30-10)*0.5 + 1.0) + 10 = (20*0.5+1)+10 = (10+1)+10 = 11+10 = 21
+    # 'category' is not used in the simple test model.
+    expected_result_val_only <- 21.0
+
+    # Expect a warning from rydra_calculate if logging fails, but not an error from the main function
+    # However, our current logging of input data is quite robust for typical list/df structures.
+    # The main concern would be if model_config or intermediates become non-serializable.
+
+    # For this test, we'll mainly check that a log is produced and contains the factor as character.
+    res <- Rydra::rydra_calculate(config_path = config_file, data = input_data_complex, model_name = "test_log_model")
+    expect_equal(res, expected_result_val_only) # Calculation should succeed
+
+    expect_true(dir.exists(log_dir))
+    log_files <- list.files(log_dir, pattern = "\\.json$")
+    expect_true(length(log_files) > 0)
+
+    log_content <- jsonlite::read_json(file.path(log_dir, log_files[1]))
+    expect_equal(log_content$invocation_params$data$val, 30)
+    expect_equal(log_content$invocation_params$data$category, "A") # Factor converted to character
+
+    unlink(config_file, force = TRUE)
+    unlink(log_dir, recursive = TRUE, force = TRUE)
+  })
+
+
+  test_that("Logging continues with warning if log directory is not writable (simulated)", {
+    # Simulating a non-writable directory is tricky and platform-dependent.
+    # We can test the behavior of dir.create failing if showWarnings = FALSE is respected
+    # and that the main calculation still proceeds. The actual logging write error is caught.
+
+    # Let's use an existing file as path, which should make dir.create fail,
+    # or jsonlite::write_json fail.
+    temp_file_as_path <- tempfile()
+    file.create(temp_file_as_path) # Create a file where a directory is expected
+
+    config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = temp_file_as_path))
+
+    input_data <- list(val = 5)
+    # Expected: ((5-10)*0.5 + 1.0) + 10 = (-5*0.5+1)+10 = (-2.5+1)+10 = -1.5+10 = 8.5
+    expected_calc_result <- 8.5
+
+    # Expect a warning from the logging system, but the calculation should complete.
+    expect_warning(
+      result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model"),
+      "Rydra logging failed"
+    )
+
+    expect_equal(result, expected_calc_result, info = "Calculation result should be correct even if logging fails.")
+
+    # The file used as path should still be a file, not a directory with logs.
+    expect_false(dir.exists(temp_file_as_path))
+    expect_true(file.exists(temp_file_as_path)) # It should remain a file
+
+    # Clean up
+    unlink(config_file, force = TRUE)
+    unlink(temp_file_as_path, force = TRUE)
+  })
+
+  # Final cleanup of any stray rydra_logs in CWD if tests failed mid-way
   if (dir.exists("rydra_logs")) unlink("rydra_logs", recursive = TRUE)
-  # Also clean up temp_log_dir if it exists (it shouldn't for this test's purpose)
-  if (dir.exists(temp_log_dir)) unlink(temp_log_dir, recursive = TRUE)
-
-  # Create a config without any logging section
-  config_file <- create_temp_config(dir = temp_log_dir)
-
-  input_data <- list(val = 15)
-
-  # Run calculation
-  Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
-
-  # Assert that the default "rydra_logs" directory is NOT created in CWD
-  expect_false(dir.exists("rydra_logs"), "Default 'rydra_logs' directory created when logging should be disabled.")
-  # Assert that no log directory was created in the temp_log_dir either (where config was)
-  expect_false(dir.exists(file.path(temp_log_dir, "rydra_logs")), "Default 'rydra_logs' created in temp test dir.")
-
-  # Clean up
-  unlink(config_file, force = TRUE)
-  unlink(temp_log_dir, recursive = TRUE, force = TRUE)
-  if (dir.exists("rydra_logs")) unlink("rydra_logs", recursive = TRUE) # General cleanup
 })
-
-test_that("Logging enabled with default path creates logs in 'rydra_logs'", {
-  # Test in a controlled temporary directory to avoid cluttering the project root with "rydra_logs"
-  test_env_dir <- file.path(tempdir(), "test_env_default_log")
-  if (dir.exists(test_env_dir)) unlink(test_env_dir, recursive = TRUE)
-  dir.create(test_env_dir, showWarnings = FALSE, recursive = TRUE)
-
-  original_wd <- getwd()
-  setwd(test_env_dir) # Set WD to ensure 'rydra_logs' is created here if default path logic works as CWD-relative
-
-  default_log_path <- "rydra_logs"
-  if (dir.exists(default_log_path)) unlink(default_log_path, recursive = TRUE) # Clean up before test
-
-  config_file <- create_temp_config(log_settings = list(enabled = TRUE), dir = test_env_dir) # Config in test_env_dir
-
-  input_data <- list(val = 20)
-
-  # Expected values for the simple model:
-  # val_centered = 20 - 10 = 10
-  # base_score = 1.0 (intercept) + (10 * 0.5) (val_centered * coeff) = 1.0 + 5.0 = 6.0
-  # total_score (pre-output) = 6.0
-  # final_result = 6.0 + 10 = 16.0
-  expected_final_result <- 16.0
-
-  result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
-  expect_equal(result, expected_final_result)
-
-  expect_true(dir.exists(default_log_path), "Default 'rydra_logs' directory was not created in the current working directory.")
-
-  log_files <- list.files(default_log_path, pattern = "\\.json$")
-  expect_true(length(log_files) > 0, "No JSON log files found in the default log directory.")
-
-  # Check content of one log file
-  log_content <- jsonlite::read_json(file.path(default_log_path, log_files[1]))
-
-  expect_true(!is.null(log_content$timestamp))
-  expect_equal(log_content$invocation_params$config_path, config_file)
-  expect_equal(log_content$invocation_params$model_name, "test_log_model")
-  expect_equal(log_content$invocation_params$data$val, input_data$val)
-  expect_true(!is.null(log_content$model_config_used))
-  expect_equal(log_content$intermediate_values$transformed_data$val_centered, 10) # (20-10)
-  expect_equal(log_content$final_result, expected_final_result)
-
-  # Filename check: YYYYMMDDHHMMSSxxxxxx_uuid.json
-  expect_true(grepl("^\\d{14}\\d{2,6}_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.json$", log_files[1]))
-
-  # Clean up
-  setwd(original_wd)
-  unlink(test_env_dir, recursive = TRUE, force = TRUE)
-})
-
-
-test_that("Logging enabled with a custom path creates logs in that path", {
-  custom_log_dir <- file.path(tempdir(), "custom_rydra_logs")
-  if (dir.exists(custom_log_dir)) unlink(custom_log_dir, recursive = TRUE) # Clean before test
-
-  config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = custom_log_dir))
-
-  input_data <- list(val = 25)
-  expected_final_result <- ((25 - 10) * 0.5 + 1.0) + 10 # 7.5 + 1.0 + 10 = 18.5
-
-  result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model")
-  expect_equal(result, expected_final_result)
-
-  expect_true(dir.exists(custom_log_dir), "Custom log directory was not created.")
-
-  log_files <- list.files(custom_log_dir, pattern = "\\.json$")
-  expect_true(length(log_files) > 0, "No JSON log files found in the custom log directory.")
-
-  log_content <- jsonlite::read_json(file.path(custom_log_dir, log_files[1]))
-  expect_equal(log_content$final_result, expected_final_result)
-  expect_equal(log_content$invocation_params$data$val, input_data$val)
-
-  # Clean up
-  unlink(config_file, force = TRUE)
-  unlink(custom_log_dir, recursive = TRUE, force = TRUE)
-})
-
-test_that("Logging handles non-serializable data gracefully (logs what it can)", {
-  # This test is more about ensuring the main calc doesn't fail if logging has an issue with complex data.
-  # The current implementation converts factors to characters, which is good.
-  # True non-serializable (like environments or connections) would error in jsonlite, caught by tryCatch.
-
-  log_dir <- file.path(tempdir(), "complex_data_log_test")
-  if (dir.exists(log_dir)) unlink(log_dir, recursive = TRUE)
-
-  config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = log_dir))
-
-  # Input data with a factor, which our logger handles by converting to character
-  input_data_complex <- list(val = 30, category = factor("A"))
-
-  # Expected calculation for 'val' part: ((30-10)*0.5 + 1.0) + 10 = (20*0.5+1)+10 = (10+1)+10 = 11+10 = 21
-  # 'category' is not used in the simple test model.
-  expected_result_val_only <- 21.0
-
-  # Expect a warning from rydra_calculate if logging fails, but not an error from the main function
-  # However, our current logging of input data is quite robust for typical list/df structures.
-  # The main concern would be if model_config or intermediates become non-serializable.
-
-  # For this test, we'll mainly check that a log is produced and contains the factor as character.
-  res <- Rydra::rydra_calculate(config_path = config_file, data = input_data_complex, model_name = "test_log_model")
-  expect_equal(res, expected_result_val_only) # Calculation should succeed
-
-  expect_true(dir.exists(log_dir))
-  log_files <- list.files(log_dir, pattern = "\\.json$")
-  expect_true(length(log_files) > 0)
-
-  log_content <- jsonlite::read_json(file.path(log_dir, log_files[1]))
-  expect_equal(log_content$invocation_params$data$val, 30)
-  expect_equal(log_content$invocation_params$data$category, "A") # Factor converted to character
-
-  unlink(config_file, force = TRUE)
-  unlink(log_dir, recursive = TRUE, force = TRUE)
-})
-
-
-test_that("Logging continues with warning if log directory is not writable (simulated)", {
-  # Simulating a non-writable directory is tricky and platform-dependent.
-  # We can test the behavior of dir.create failing if showWarnings = FALSE is respected
-  # and that the main calculation still proceeds. The actual logging write error is caught.
-
-  # Let's use an existing file as path, which should make dir.create fail,
-  # or jsonlite::write_json fail.
-  temp_file_as_path <- tempfile()
-  file.create(temp_file_as_path) # Create a file where a directory is expected
-
-  config_file <- create_temp_config(log_settings = list(enabled = TRUE, path = temp_file_as_path))
-
-  input_data <- list(val = 5)
-  # Expected: ((5-10)*0.5 + 1.0) + 10 = (-5*0.5+1)+10 = (-2.5+1)+10 = -1.5+10 = 8.5
-  expected_calc_result <- 8.5
-
-  # Expect a warning from the logging system, but the calculation should complete.
-  expect_warning(
-    result <- Rydra::rydra_calculate(config_path = config_file, data = input_data, model_name = "test_log_model"),
-    "Rydra logging failed"
-  )
-
-  expect_equal(result, expected_calc_result, info = "Calculation result should be correct even if logging fails.")
-
-  # The file used as path should still be a file, not a directory with logs.
-  expect_false(dir.exists(temp_file_as_path))
-  expect_true(file.exists(temp_file_as_path)) # It should remain a file
-
-  # Clean up
-  unlink(config_file, force = TRUE)
-  unlink(temp_file_as_path, force = TRUE)
-})
-
-# Final cleanup of any stray rydra_logs in CWD if tests failed mid-way
-if (dir.exists("rydra_logs")) unlink("rydra_logs", recursive = TRUE)

--- a/tests/testthat/test-output_transformation.R
+++ b/tests/testthat/test-output_transformation.R
@@ -1,129 +1,129 @@
-context("Output Transformation Logic")
+test_that("Output Transformation Logic", {
+  library(testthat)
+  library(Rydra) # Ensures Rydra functions are available
 
-library(testthat)
-library(Rydra) # Ensures Rydra functions are available
+  # Base config path for output transformation tests
+  base_config_path_output <- system.file("extdata", "test_config_output_transform.yaml", package = "Rydra")
+  if (base_config_path_output == "") { # Fallback for dev environment
+      base_config_path_output <- "inst/extdata/test_config_output_transform.yaml"
+  }
 
-# Base config path for output transformation tests
-base_config_path_output <- system.file("extdata", "test_config_output_transform.yaml", package = "Rydra")
-if (base_config_path_output == "") { # Fallback for dev environment
-    base_config_path_output <- "inst/extdata/test_config_output_transform.yaml"
-}
+  # Helper function to run rydra_calculate with a modified output_transformation
+  # and optionally a custom set of transformation functions
+  run_with_output_transform <- function(output_expr_string, transformations_list = Rydra:::.default_rydra_transformations) {
+    config <- yaml::read_yaml(base_config_path_output)
+    config$output_transform_test_model$output_transformation <- output_expr_string
 
-# Helper function to run rydra_calculate with a modified output_transformation
-# and optionally a custom set of transformation functions
-run_with_output_transform <- function(output_expr_string, transformations_list = Rydra:::.default_rydra_transformations) {
-  config <- yaml::read_yaml(base_config_path_output)
-  config$output_transform_test_model$output_transformation <- output_expr_string
+    temp_config_file <- tempfile(fileext = ".yaml")
+    yaml::write_yaml(config, temp_config_file)
+    on.exit(unlink(temp_config_file))
 
-  temp_config_file <- tempfile(fileext = ".yaml")
-  yaml::write_yaml(config, temp_config_file)
-  on.exit(unlink(temp_config_file))
+    # Input data is minimal as only baseline intercept matters for these tests before output_transformation
+    input_data <- list()
 
-  # Input data is minimal as only baseline intercept matters for these tests before output_transformation
-  input_data <- list()
+    # Initial result before output_transformation is baseline = 10 (from test_config_output_transform.yaml)
+    rydra_calculate(
+      config_path = temp_config_file,
+      data = input_data,
+      model_name = "output_transform_test_model",
+      transformations = transformations_list
+    )
+  }
 
-  # Initial result before output_transformation is baseline = 10 (from test_config_output_transform.yaml)
-  rydra_calculate(
-    config_path = temp_config_file,
-    data = input_data,
-    model_name = "output_transform_test_model",
-    transformations = transformations_list
-  )
-}
+  test_that("Output transformation: using multiply_by", {
+    # Initial result = 10. Output: multiply_by(result, 5)
+    expect_equal(run_with_output_transform("multiply_by(result, 5)"), 50)
+    expect_equal(run_with_output_transform("multiply_by(result, 0)"), 0)
+    expect_equal(run_with_output_transform("multiply_by(result, -2)"), -20)
+    expect_equal(run_with_output_transform("multiply_by(result, 1.5)"), 15)
+  })
 
-test_that("Output transformation: using multiply_by", {
-  # Initial result = 10. Output: multiply_by(result, 5)
-  expect_equal(run_with_output_transform("multiply_by(result, 5)"), 50)
-  expect_equal(run_with_output_transform("multiply_by(result, 0)"), 0)
-  expect_equal(run_with_output_transform("multiply_by(result, -2)"), -20)
-  expect_equal(run_with_output_transform("multiply_by(result, 1.5)"), 15)
-})
+  test_that("Output transformation: using add_value", {
+    # Initial result = 10. Output: add_value(result, 5)
+    expect_equal(run_with_output_transform("add_value(result, 5)"), 15)
+    expect_equal(run_with_output_transform("add_value(result, -5)"), 5)
+    expect_equal(run_with_output_transform("add_value(result, 0)"), 10)
+    expect_equal(run_with_output_transform("add_value(result, 2.5)"), 12.5)
+  })
 
-test_that("Output transformation: using add_value", {
-  # Initial result = 10. Output: add_value(result, 5)
-  expect_equal(run_with_output_transform("add_value(result, 5)"), 15)
-  expect_equal(run_with_output_transform("add_value(result, -5)"), 5)
-  expect_equal(run_with_output_transform("add_value(result, 0)"), 10)
-  expect_equal(run_with_output_transform("add_value(result, 2.5)"), 12.5)
-})
+  test_that("Output transformation: using existing log_transform from default transformations", {
+    # Initial result = 10.
+    expect_equal(run_with_output_transform("log_transform(result)"), log(10))
+    expect_equal(run_with_output_transform("log_transform(result, base = 10)"), log(10, base = 10))
+  })
 
-test_that("Output transformation: using existing log_transform from default transformations", {
-  # Initial result = 10.
-  expect_equal(run_with_output_transform("log_transform(result)"), log(10))
-  expect_equal(run_with_output_transform("log_transform(result, base = 10)"), log(10, base = 10))
-})
+  test_that("Output transformation: chaining allowed functions (if they are part of the expression)", {
+    # Initial result = 10. multiply_by(add_value(result, 5), 2) = multiply_by(15, 2) = 30
+    expect_equal(run_with_output_transform("multiply_by(add_value(result, 5), 2)"), 30)
+  })
 
-test_that("Output transformation: chaining allowed functions (if they are part of the expression)", {
-  # Initial result = 10. multiply_by(add_value(result, 5), 2) = multiply_by(15, 2) = 30
-  expect_equal(run_with_output_transform("multiply_by(add_value(result, 5), 2)"), 30)
-})
+  test_that("Output transformation: no transformation if string is empty", {
+    # Initial result = 10.
+    expect_equal(run_with_output_transform(""), 10)
+  })
 
-test_that("Output transformation: no transformation if string is empty", {
-  # Initial result = 10.
-  expect_equal(run_with_output_transform(""), 10)
-})
+  test_that("Output transformation: no transformation if section is NULL", {
+    config <- yaml::read_yaml(base_config_path_output)
+    config$output_transform_test_model$output_transformation <- NULL
 
-test_that("Output transformation: no transformation if section is NULL", {
-  config <- yaml::read_yaml(base_config_path_output)
-  config$output_transform_test_model$output_transformation <- NULL
+    temp_config_file <- tempfile(fileext = ".yaml")
+    yaml::write_yaml(config, temp_config_file)
+    on.exit(unlink(temp_config_file))
 
-  temp_config_file <- tempfile(fileext = ".yaml")
-  yaml::write_yaml(config, temp_config_file)
-  on.exit(unlink(temp_config_file))
+    input_data <- list()
+    actual_value <- rydra_calculate(
+      config_path = temp_config_file,
+      data = input_data,
+      model_name = "output_transform_test_model"
+      # uses default transformations
+    )
+    expect_equal(actual_value, 10)
+  })
 
-  input_data <- list()
-  actual_value <- rydra_calculate(
-    config_path = temp_config_file,
-    data = input_data,
-    model_name = "output_transform_test_model"
-    # uses default transformations
-  )
-  expect_equal(actual_value, 10)
-})
+  test_that("Output transformation: error if function is not in available transformations", {
+    # Initial result = 10. unknown_function is not in .default_rydra_transformations
+    expect_error(run_with_output_transform("unknown_function(result, 1)"),
+                 regexp = "Output transformation function 'unknown_function'.*not found in the available transformations list")
 
-test_that("Output transformation: error if function is not in available transformations", {
-  # Initial result = 10. unknown_function is not in .default_rydra_transformations
-  expect_error(run_with_output_transform("unknown_function(result, 1)"),
-               regexp = "Output transformation function 'unknown_function'.*not found in the available transformations list")
+    # Test with a custom list of transformations that doesn't include multiply_by
+    custom_transforms <- list(some_other_func = function(x) x + 1)
+    expect_error(run_with_output_transform("multiply_by(result, 10)", transformations_list = custom_transforms),
+                 regexp = "Output transformation function 'multiply_by'.*not found in the available transformations list")
+  })
 
-  # Test with a custom list of transformations that doesn't include multiply_by
-  custom_transforms <- list(some_other_func = function(x) x + 1)
-  expect_error(run_with_output_transform("multiply_by(result, 10)", transformations_list = custom_transforms),
-               regexp = "Output transformation function 'multiply_by'.*not found in the available transformations list")
-})
-
-test_that("Output transformation: error for invalid function call format (not a function call)", {
-  expect_error(run_with_output_transform("result * 10"),
-               regexp = "Output transformation 'result \\* 10' is not a valid function call format")
-  expect_error(run_with_output_transform("result + 5"),
-               regexp = "Output transformation 'result \\+ 5' is not a valid function call format")
-  expect_error(run_with_output_transform("100"), # Just a number, not a function call
-               regexp = "Output transformation '100' is not a valid function call format")
-})
+  test_that("Output transformation: error for invalid function call format (not a function call)", {
+    expect_error(run_with_output_transform("result * 10"),
+                 regexp = "Output transformation 'result \\* 10' is not a valid function call format")
+    expect_error(run_with_output_transform("result + 5"),
+                 regexp = "Output transformation 'result \\+ 5' is not a valid function call format")
+    expect_error(run_with_output_transform("100"), # Just a number, not a function call
+                 regexp = "Output transformation '100' is not a valid function call format")
+  })
 
 
-test_that("Output transformation: error during evaluation (e.g. wrong number of args, type error)", {
-  # multiply_by expects 2 args, given 1 (result is implicitly the first, then needs one more)
-  expect_error(run_with_output_transform("multiply_by(result)"),
-               regexp = "Error evaluating output transformation .*argument \"multiplier\" is missing")
+  test_that("Output transformation: error during evaluation (e.g. wrong number of args, type error)", {
+    # multiply_by expects 2 args, given 1 (result is implicitly the first, then needs one more)
+    expect_error(run_with_output_transform("multiply_by(result)"),
+                 regexp = "Error evaluating output transformation .*argument \"multiplier\" is missing")
 
-  # add_value expects 2 args, given 3
-  expect_error(run_with_output_transform("add_value(result, 5, 10)"),
-               regexp = "Error evaluating output transformation .*unused argument (10)") # R's error for too many args
+    # add_value expects 2 args, given 3
+    expect_error(run_with_output_transform("add_value(result, 5, 10)"),
+                 regexp = "Error evaluating output transformation .*unused argument (10)") # R's error for too many args
 
-  # Type error within the function
-  expect_error(run_with_output_transform("multiply_by(result, \"a_string\")"),
-               regexp = "Error evaluating output transformation .*non-numeric argument to binary operator")
-})
+    # Type error within the function
+    expect_error(run_with_output_transform("multiply_by(result, \"a_string\")"),
+                 regexp = "Error evaluating output transformation .*non-numeric argument to binary operator")
+  })
 
-test_that("Output transformation: references a non-existent variable within arguments", {
-  # Initial result = 10. non_existent_var is not in eval_env_output
-  expect_error(run_with_output_transform("multiply_by(result, non_existent_var)"),
-               regexp = "Error evaluating output transformation .*object 'non_existent_var' not found")
-})
+  test_that("Output transformation: references a non-existent variable within arguments", {
+    # Initial result = 10. non_existent_var is not in eval_env_output
+    expect_error(run_with_output_transform("multiply_by(result, non_existent_var)"),
+                 regexp = "Error evaluating output transformation .*object 'non_existent_var' not found")
+  })
 
-test_that("Output transformation: using centering constants if available in env", {
-  # test_config_output_transform.yaml has centering: { my_center: 3 }
-  # initial result = 10. multiply_by(result, centering.my_center) = 10 * 3 = 30
-  expect_equal(run_with_output_transform("multiply_by(result, centering.my_center)"), 30)
+  test_that("Output transformation: using centering constants if available in env", {
+    # test_config_output_transform.yaml has centering: { my_center: 3 }
+    # initial result = 10. multiply_by(result, centering.my_center) = 10 * 3 = 30
+    expect_equal(run_with_output_transform("multiply_by(result, centering.my_center)"), 30)
+  })
 })

--- a/tests/testthat/test-test_calculate.R
+++ b/tests/testthat/test-test_calculate.R
@@ -1,106 +1,106 @@
-library(testthat)
-# No need to library(Rydra) here if tests/testthat.R does it,
-# but good practice for individual file runs.
-# library(Rydra)
+test_that("rydra_calculate main functionality", {
+  library(testthat)
+  # No need to library(Rydra) here if tests/testthat.R does it,
+  # but good practice for individual file runs.
+  # library(Rydra)
 
-context("rydra_calculate main functionality")
-
-test_that("rydra_calculate computes correct value with example_config", {
-  # Path to the example config file
-  # system.file returns path to installed files, need to adjust for local testing
-  # For testing during development, relative paths from package root are easier.
-  config_file_path <- file.path("..", "..", "inst", "extdata", "example_config.yaml")
-  # A more robust way if tests are run from package root:
-  # config_file_path <- "inst/extdata/example_config.yaml"
-  # Let's ensure it finds it from `tests/testthat/`
-  if (!file.exists(config_file_path)) { # if run from tests/testthat
-    config_file_path <- system.file("extdata", "example_config.yaml", package = "Rydra", mustWork = FALSE)
-    if (config_file_path == "") { # if package not installed, try relative from project root for dev
-      config_file_path <- "../../inst/extdata/example_config.yaml" # from tests/testthat to inst/extdata
-      if (!file.exists(config_file_path)) {
-        config_file_path <- "inst/extdata/example_config.yaml" # from project root
+  test_that("rydra_calculate computes correct value with example_config", {
+    # Path to the example config file
+    # system.file returns path to installed files, need to adjust for local testing
+    # For testing during development, relative paths from package root are easier.
+    config_file_path <- file.path("..", "..", "inst", "extdata", "example_config.yaml")
+    # A more robust way if tests are run from package root:
+    # config_file_path <- "inst/extdata/example_config.yaml"
+    # Let's ensure it finds it from `tests/testthat/`
+    if (!file.exists(config_file_path)) { # if run from tests/testthat
+      config_file_path <- system.file("extdata", "example_config.yaml", package = "Rydra", mustWork = FALSE)
+      if (config_file_path == "") { # if package not installed, try relative from project root for dev
+        config_file_path <- "../../inst/extdata/example_config.yaml" # from tests/testthat to inst/extdata
+        if (!file.exists(config_file_path)) {
+          config_file_path <- "inst/extdata/example_config.yaml" # from project root
+        }
       }
     }
-  }
 
-  # Ensure the config file exists at the determined path
-  expect_true(file.exists(config_file_path),
-              info = paste("Config file not found at:", config_file_path, "CWD:", getwd()))
+    # Ensure the config file exists at the determined path
+    expect_true(file.exists(config_file_path),
+                info = paste("Config file not found at:", config_file_path, "CWD:", getwd()))
 
-  # Corrected input data for example_config.yaml and its 'main_model'
-  input_data <- list(
-    age = 35,
-    income = 60000,
-    student = 1, # This corresponds to student_modifier
-    employment_status = "Unemployed" # Corresponds to employment_unemployed
-  )
+    # Corrected input data for example_config.yaml and its 'main_model'
+    input_data <- list(
+      age = 35,
+      income = 60000,
+      student = 1, # This corresponds to student_modifier
+      employment_status = "Unemployed" # Corresponds to employment_unemployed
+    )
 
-  # Manually calculated expected result for example_config.yaml with 'main_model':
-  # Centering: age: 30, income: 50000
-  # Transformations:
-  #   age_centered = center_variable(35, 30) = 5
-  #   age_squared_centered = square_variable(5) = 25
-  #   income_log = log_transform(60000) approx 11.002102
-  # Intercepts: baseline: 1.25
-  # Coefficients (direct terms):
-  #   age_centered: 0.05 * 5 = 0.25
-  #   age_squared_centered: -0.02 * 25 = -0.50
-  #   income_log: 0.15 * 11.002102 = 1.6503153
-  # Base Score = 1.25 + 0.25 - 0.50 + 1.6503153 = 2.6503153
-  # Factors:
-  #   student = 1 -> student_modifier = -0.50
-  #   employment_status = "Unemployed" -> employment_unemployed = -0.25
-  # Factor Sum = -0.50 + (-0.25) = -0.75
-  # Conditions: None in example_config.yaml, so sum = 0.
-  # Total Score = Base Score + Factor Sum + Conditions Sum = 2.6503153 - 0.75 + 0 = 1.9003153
-  # Output Transformation: result * 100 = 1.9003153 * 100 = 190.03153
-  expected_value <- 190.03153
+    # Manually calculated expected result for example_config.yaml with 'main_model':
+    # Centering: age: 30, income: 50000
+    # Transformations:
+    #   age_centered = center_variable(35, 30) = 5
+    #   age_squared_centered = square_variable(5) = 25
+    #   income_log = log_transform(60000) approx 11.002102
+    # Intercepts: baseline: 1.25
+    # Coefficients (direct terms):
+    #   age_centered: 0.05 * 5 = 0.25
+    #   age_squared_centered: -0.02 * 25 = -0.50
+    #   income_log: 0.15 * 11.002102 = 1.6503153
+    # Base Score = 1.25 + 0.25 - 0.50 + 1.6503153 = 2.6503153
+    # Factors:
+    #   student = 1 -> student_modifier = -0.50
+    #   employment_status = "Unemployed" -> employment_unemployed = -0.25
+    # Factor Sum = -0.50 + (-0.25) = -0.75
+    # Conditions: None in example_config.yaml, so sum = 0.
+    # Total Score = Base Score + Factor Sum + Conditions Sum = 2.6503153 - 0.75 + 0 = 1.9003153
+    # Output Transformation: result * 100 = 1.9003153 * 100 = 190.03153
+    expected_value <- 190.03153
 
-  # Use model_name = "main_model" as defined in example_config.yaml
-  actual_value <- Rydra::rydra_calculate(
-    config_path = config_file_path,
-    data = input_data,
-    model_name = "main_model" # Specify the correct model name
-  )
+    # Use model_name = "main_model" as defined in example_config.yaml
+    actual_value <- Rydra::rydra_calculate(
+      config_path = config_file_path,
+      data = input_data,
+      model_name = "main_model" # Specify the correct model name
+    )
 
-  expect_equal(actual_value, expected_value, tolerance = 1e-5) # Adjusted tolerance slightly
-})
+    expect_equal(actual_value, expected_value, tolerance = 1e-5) # Adjusted tolerance slightly
+  })
 
-test_that("load_config handles non-existent file", {
-  expect_error(load_config("path/to/non_existent_config.yaml"),
-               "Configuration file not found: path/to/non_existent_config.yaml")
-})
+  test_that("load_config handles non-existent file", {
+    expect_error(load_config("path/to/non_existent_config.yaml"),
+                 "Configuration file not found: path/to/non_existent_config.yaml")
+  })
 
-test_that("apply_transformations works correctly", {
-  config <- list(
-    centering = list(ga_days = 77),
-    plgf_model = list(
-      transformations = list(
-        list(name = "ga_centered", formula = "ga * 7 - centering.ga_days")
+  test_that("apply_transformations works correctly", {
+    config <- list(
+      centering = list(ga_days = 77),
+      plgf_model = list(
+        transformations = list(
+          list(name = "ga_centered", formula = "ga * 7 - centering.ga_days")
+        )
       )
     )
-  )
-  data <- data.frame(ga = 12) # ga in weeks
-  transformed_data <- apply_transformations(config, data)
-  expect_equal(transformed_data$ga_centered, 12 * 7 - 77)
-})
+    data <- data.frame(ga = 12) # ga in weeks
+    transformed_data <- apply_transformations(config, data)
+    expect_equal(transformed_data$ga_centered, 12 * 7 - 77)
+  })
 
-test_that("apply_conditions works correctly", {
-  config <- list(
-    plgf_model = list(
-      intercepts = list(delfia = 1.5),
-      coefficients = list(smoker_coeff = 0.5),
-      conditions = list(
-        list(name = "is_delfia", condition = "machine == 'delfia'", coefficient = "intercepts.delfia"),
-        list(name = "is_smoker", condition = "smoking == TRUE", coefficient = "coefficients.smoker_coeff")
+  test_that("apply_conditions works correctly", {
+    config <- list(
+      plgf_model = list(
+        intercepts = list(delfia = 1.5),
+        coefficients = list(smoker_coeff = 0.5),
+        conditions = list(
+          list(name = "is_delfia", condition = "machine == 'delfia'", coefficient = "intercepts.delfia"),
+          list(name = "is_smoker", condition = "smoking == TRUE", coefficient = "coefficients.smoker_coeff")
+        )
       )
     )
-  )
-  data <- list(machine = "delfia", smoking = TRUE)
-  total_conditional_coeff <- apply_conditions(config, data)
-  expect_equal(total_conditional_coeff, 1.5 + 0.5)
+    data <- list(machine = "delfia", smoking = TRUE)
+    total_conditional_coeff <- apply_conditions(config, data)
+    expect_equal(total_conditional_coeff, 1.5 + 0.5)
 
-  data_no_smoke <- list(machine = "other", smoking = FALSE)
-  total_conditional_coeff_no_smoke <- apply_conditions(config, data_no_smoke)
-  expect_equal(total_conditional_coeff_no_smoke, 0)
+    data_no_smoke <- list(machine = "other", smoking = FALSE)
+    total_conditional_coeff_no_smoke <- apply_conditions(config, data_no_smoke)
+    expect_equal(total_conditional_coeff_no_smoke, 0)
+  })
 })

--- a/tests/testthat/test-transformation_defaults.R
+++ b/tests/testthat/test-transformation_defaults.R
@@ -1,107 +1,106 @@
-context("Transformation Defaults and Overrides")
+test_that("Transformation Defaults and Overrides", {
+  library(testthat)
+  library(Rydra)
 
-library(testthat)
-library(Rydra)
+  # Config path for these tests
+  config_path_simple_transform <- system.file("extdata", "test_config_simple_transform.yaml", package = "Rydra")
+  if (config_path_simple_transform == "") { # Fallback for dev environment
+      config_path_simple_transform <- "inst/extdata/test_config_simple_transform.yaml"
+  }
 
-# Config path for these tests
-config_path_simple_transform <- system.file("extdata", "test_config_simple_transform.yaml", package = "Rydra")
-if (config_path_simple_transform == "") { # Fallback for dev environment
-    config_path_simple_transform <- "inst/extdata/test_config_simple_transform.yaml"
-}
+  test_that("Base transformations are used by default", {
+    # test_config_simple_transform.yaml uses center_variable and log_transform
+    input_data <- list(val_a = 15, val_b = exp(2)) # centering.val_a = 10
 
-test_that("Base transformations are used by default", {
-  # test_config_simple_transform.yaml uses center_variable and log_transform
-  input_data <- list(val_a = 15, val_b = exp(2)) # centering.val_a = 10
+    # val_a_centered = 15 - 10 = 5
+    # val_b_logged = log(exp(2)) = 2
+    # result = baseline(0) + 1*5 + 2*2 = 9
+    expected_value <- 9
 
-  # val_a_centered = 15 - 10 = 5
-  # val_b_logged = log(exp(2)) = 2
-  # result = baseline(0) + 1*5 + 2*2 = 9
-  expected_value <- 9
+    # Call rydra_calculate WITHOUT providing the 'transformations' argument
+    actual_value <- rydra_calculate(
+      config_path = config_path_simple_transform,
+      data = input_data,
+      model_name = "transform_test_model"
+    )
+    expect_equal(actual_value, expected_value, tolerance = 1e-7)
+  })
 
-  # Call rydra_calculate WITHOUT providing the 'transformations' argument
-  actual_value <- rydra_calculate(
-    config_path = config_path_simple_transform,
-    data = input_data,
-    model_name = "transform_test_model"
-  )
-  expect_equal(actual_value, expected_value, tolerance = 1e-7)
-})
+  test_that("Providing transformations = list() excludes defaults", {
+    input_data <- list(val_a = 15, val_b = exp(2))
 
-test_that("Providing transformations = list() excludes defaults", {
-  input_data <- list(val_a = 15, val_b = exp(2))
+    # Expect a warning because center_variable and log_transform won't be found
+    # The transformation will likely result in NA or an error during eval,
+    # leading to issues in the sum.
+    # The functions `center_variable` etc. are not in the empty list, so eval will fail.
+    # `eval(parse(text = trans$formula), envir = eval_env)` will error.
+    expect_warning(
+      rydra_calculate(
+        config_path = config_path_simple_transform,
+        data = input_data,
+        model_name = "transform_test_model",
+        transformations = list() # Provide empty list
+      ),
+      regexp = "Error evaluating transformation" # Expect warnings from eval failures
+    )
 
-  # Expect a warning because center_variable and log_transform won't be found
-  # The transformation will likely result in NA or an error during eval,
-  # leading to issues in the sum.
-  # The functions `center_variable` etc. are not in the empty list, so eval will fail.
-  # `eval(parse(text = trans$formula), envir = eval_env)` will error.
-  expect_warning(
-    rydra_calculate(
+    # A more specific error or NA propagation test might be better,
+    # but for now, checking for the warning from eval is a good start.
+    # The result might be NA or an error depending on how errors in eval are handled.
+    # If eval error stops execution, then expect_error.
+    # Current apply_transformations has a tryCatch that issues a warning.
+    # So, the calculation will proceed but with NAs for failed transforms if they are not caught earlier.
+    # If val_a_centered becomes NA, then result becomes NA.
+    # If coefficients are not found, they are skipped. If data values are NA, NA * coeff = NA.
+    # Baseline is 0. So result is likely NA.
+      val <- suppressWarnings(
+          rydra_calculate(
+              config_path = config_path_simple_transform,
+              data = input_data,
+              model_name = "transform_test_model",
+              transformations = list()
+          )
+      )
+      expect_true(is.na(val) || !is.finite(val)) # Expect NA or non-finite if transform fails
+  })
+
+  test_that("Custom transformation overrides default base function with the same name", {
+    input_data <- list(val_a = 15, val_b = 100) # centering.val_a = 10
+
+    # Custom log_transform that returns log10(x)
+    custom_log_transform <- function(x) { log10(x) }
+
+    # All other base functions should still be available from default partial list
+    # if we construct the list carefully.
+    # However, the current setup is: user list REPLACES default list.
+    # So, we must provide all needed functions if we override one.
+    # The test_config_simple_transform also uses center_variable.
+
+    custom_transformations = list(
+      log_transform = custom_log_transform,
+      center_variable = Rydra::center_variable # Need to re-include other used base functions
+      # square_variable = Rydra::square_variable, # Not used by this config
+      # exp_transform = Rydra::exp_transform    # Not used by this config
+    )
+
+    # val_a_centered = 15 - 10 = 5 (using Rydra::center_variable)
+    # val_b_logged = log10(100) = 2 (using custom_log_transform)
+    # result = baseline(0) + 1*5 + 2*2 = 9
+    expected_value <- 9
+
+    actual_value <- rydra_calculate(
       config_path = config_path_simple_transform,
       data = input_data,
       model_name = "transform_test_model",
-      transformations = list() # Provide empty list
-    ),
-    regexp = "Error evaluating transformation" # Expect warnings from eval failures
-  )
-
-  # A more specific error or NA propagation test might be better,
-  # but for now, checking for the warning from eval is a good start.
-  # The result might be NA or an error depending on how errors in eval are handled.
-  # If eval error stops execution, then expect_error.
-  # Current apply_transformations has a tryCatch that issues a warning.
-  # So, the calculation will proceed but with NAs for failed transforms if they are not caught earlier.
-  # If val_a_centered becomes NA, then result becomes NA.
-  # If coefficients are not found, they are skipped. If data values are NA, NA * coeff = NA.
-  # Baseline is 0. So result is likely NA.
-    val <- suppressWarnings(
-        rydra_calculate(
-            config_path = config_path_simple_transform,
-            data = input_data,
-            model_name = "transform_test_model",
-            transformations = list()
-        )
+      transformations = custom_transformations
     )
-    expect_true(is.na(val) || !is.finite(val)) # Expect NA or non-finite if transform fails
-})
+    expect_equal(actual_value, expected_value, tolerance = 1e-7)
+  })
 
-test_that("Custom transformation overrides default base function with the same name", {
-  input_data <- list(val_a = 15, val_b = 100) # centering.val_a = 10
-
-  # Custom log_transform that returns log10(x)
-  custom_log_transform <- function(x) { log10(x) }
-
-  # All other base functions should still be available from default partial list
-  # if we construct the list carefully.
-  # However, the current setup is: user list REPLACES default list.
-  # So, we must provide all needed functions if we override one.
-  # The test_config_simple_transform also uses center_variable.
-
-  custom_transformations = list(
-    log_transform = custom_log_transform,
-    center_variable = Rydra::center_variable # Need to re-include other used base functions
-    # square_variable = Rydra::square_variable, # Not used by this config
-    # exp_transform = Rydra::exp_transform    # Not used by this config
-  )
-
-  # val_a_centered = 15 - 10 = 5 (using Rydra::center_variable)
-  # val_b_logged = log10(100) = 2 (using custom_log_transform)
-  # result = baseline(0) + 1*5 + 2*2 = 9
-  expected_value <- 9
-
-  actual_value <- rydra_calculate(
-    config_path = config_path_simple_transform,
-    data = input_data,
-    model_name = "transform_test_model",
-    transformations = custom_transformations
-  )
-  expect_equal(actual_value, expected_value, tolerance = 1e-7)
-})
-
-test_that("Custom transformation with a new name works alongside defaults", {
-  # Modify YAML in memory for this test or use a new YAML.
-  # Let's use a slightly different config string for this.
-  temp_config_text <- '
+  test_that("Custom transformation with a new name works alongside defaults", {
+    # Modify YAML in memory for this test or use a new YAML.
+    # Let's use a slightly different config string for this.
+    temp_config_text <- '
 model_name: "custom_transform_test"
 centering:
   val_a: 10
@@ -119,98 +118,98 @@ custom_transform_test:
   factors: []
   output_transformation: "result"
 '
-  temp_config_file <- tempfile(fileext = ".yaml")
-  writeLines(temp_config_text, temp_config_file)
-  on.exit(unlink(temp_config_file))
+    temp_config_file <- tempfile(fileext = ".yaml")
+    writeLines(temp_config_text, temp_config_file)
+    on.exit(unlink(temp_config_file))
 
-  my_custom_doubler_func <- function(x) { x * 2 }
+    my_custom_doubler_func <- function(x) { x * 2 }
 
-  # User provides ONLY their new function. Defaults should still apply for others.
-  # This test relies on the .default_rydra_transformations being merged with user's list,
-  # if user list doesn't override.
-  # The current plan: user list REPLACES default. So this test needs to be adjusted.
-  # If user provides a list, that's IT. No merging.
-  # So, if they want `center_variable` AND `my_custom_doubler`, they must provide both.
+    # User provides ONLY their new function. Defaults should still apply for others.
+    # This test relies on the .default_rydra_transformations being merged with user's list,
+    # if user list doesn't override.
+    # The current plan: user list REPLACES default. So this test needs to be adjusted.
+    # If user provides a list, that's IT. No merging.
+    # So, if they want `center_variable` AND `my_custom_doubler`, they must provide both.
 
-  user_funcs_only_custom <- list(
-    my_custom_doubler = my_custom_doubler_func
-    # center_variable is NOT provided here.
-  )
+    user_funcs_only_custom <- list(
+      my_custom_doubler = my_custom_doubler_func
+      # center_variable is NOT provided here.
+    )
 
-  input_data <- list(val_a = 12, val_c = 5) # centering.val_a = 10
+    input_data <- list(val_a = 12, val_c = 5) # centering.val_a = 10
 
-  # With current replacement logic:
-  # center_variable will NOT be found if only `my_custom_doubler` is passed.
-  # So, val_a_centered will fail to compute.
-  # This test should demonstrate that.
+    # With current replacement logic:
+    # center_variable will NOT be found if only `my_custom_doubler` is passed.
+    # So, val_a_centered will fail to compute.
+    # This test should demonstrate that.
 
-  expect_warning(
-    rydra_calculate(
+    expect_warning(
+      rydra_calculate(
+        config_path = temp_config_file,
+        data = input_data,
+        model_name = "custom_transform_test",
+        transformations = user_funcs_only_custom
+      ),
+      regexp = "Error evaluating transformation 'val_a_centered'"
+    )
+
+    # Now, test providing BOTH custom and necessary base functions
+    user_funcs_mixed <- list(
+      my_custom_doubler = my_custom_doubler_func,
+      center_variable = Rydra::center_variable # Explicitly include needed base func
+    )
+
+    # val_a_centered = 12 - 10 = 2 (using base center_variable)
+    # val_c_custom = my_custom_doubler(5) = 10 (using custom function)
+    # result = baseline(1) + 1*2 + 3*10 = 1 + 2 + 30 = 33
+    expected_value_mixed <- 33
+
+    actual_value_mixed <- rydra_calculate(
       config_path = temp_config_file,
       data = input_data,
       model_name = "custom_transform_test",
-      transformations = user_funcs_only_custom
-    ),
-    regexp = "Error evaluating transformation 'val_a_centered'"
-  )
+      transformations = user_funcs_mixed
+    )
+    expect_equal(actual_value_mixed, expected_value_mixed, tolerance = 1e-7)
+  })
 
-  # Now, test providing BOTH custom and necessary base functions
-  user_funcs_mixed <- list(
-    my_custom_doubler = my_custom_doubler_func,
-    center_variable = Rydra::center_variable # Explicitly include needed base func
-  )
+  # Test for the hardcoded plgf_model issue in apply_transformations
+  # This test will currently FAIL because apply_transformations uses config$plgf_model
+  # instead of the actual model_name from the rydra_calculate call.
+  # Once that is fixed, this test should pass.
+  test_that("apply_transformations uses the correct model_name from rydra_calculate", {
+    # test_config_simple_transform.yaml defines "transform_test_model"
+    # If apply_transformations incorrectly looks for "plgf_model" in this config,
+    # it will not find any transformations to apply (or error if plgf_model doesn't exist)
+    # and the calculation would be wrong.
 
-  # val_a_centered = 12 - 10 = 2 (using base center_variable)
-  # val_c_custom = my_custom_doubler(5) = 10 (using custom function)
-  # result = baseline(1) + 1*2 + 3*10 = 1 + 2 + 30 = 33
-  expected_value_mixed <- 33
+    input_data <- list(val_a = 15, val_b = exp(2))
+    expected_value <- 9 # Same as the first test
 
-  actual_value_mixed <- rydra_calculate(
-    config_path = temp_config_file,
-    data = input_data,
-    model_name = "custom_transform_test",
-    transformations = user_funcs_mixed
-  )
-  expect_equal(actual_value_mixed, expected_value_mixed, tolerance = 1e-7)
-})
+    # This call uses model_name = "transform_test_model"
+    actual_value <- rydra_calculate(
+      config_path = config_path_simple_transform,
+      data = input_data,
+      model_name = "transform_test_model" # Explicitly use the model in the YAML
+    )
 
-# Test for the hardcoded plgf_model issue in apply_transformations
-# This test will currently FAIL because apply_transformations uses config$plgf_model
-# instead of the actual model_name from the rydra_calculate call.
-# Once that is fixed, this test should pass.
-test_that("apply_transformations uses the correct model_name from rydra_calculate", {
-  # test_config_simple_transform.yaml defines "transform_test_model"
-  # If apply_transformations incorrectly looks for "plgf_model" in this config,
-  # it will not find any transformations to apply (or error if plgf_model doesn't exist)
-  # and the calculation would be wrong.
+    # If apply_transformations internally hardcodes plgf_model, it might find no transformations
+    # in test_config_simple_transform.yaml under that name.
+    # If no transformations are found, val_a_centered and val_b_logged would not be created.
+    # Then the score would be baseline (0) + (1 * data$val_a_centered) + (2 * data$val_b_logged).
+    # If these are NULL/NA, score would be 0 or NA.
+    # If it correctly uses "transform_test_model", the result is 9.
+    expect_equal(actual_value, expected_value, tolerance = 1e-7,
+                 info = "This test checks if apply_transformations correctly uses the model_name passed to rydra_calculate. It might fail if apply_transformations hardcodes 'plgf_model'.")
+  })
 
-  input_data <- list(val_a = 15, val_b = exp(2))
-  expected_value <- 9 # Same as the first test
+  # Add the new test file to tests/testthat.R if it's not automatically picked up.
+  # Typically, testthat runs all files matching `test-*.R` in this directory.
+  # Make sure basic_transformations functions are exported by Rydra package. (They are)
+  # Make sure to run devtools::load_all() or install the package before testing.
 
-  # This call uses model_name = "transform_test_model"
-  actual_value <- rydra_calculate(
-    config_path = config_path_simple_transform,
-    data = input_data,
-    model_name = "transform_test_model" # Explicitly use the model in the YAML
-  )
-
-  # If apply_transformations internally hardcodes plgf_model, it might find no transformations
-  # in test_config_simple_transform.yaml under that name.
-  # If no transformations are found, val_a_centered and val_b_logged would not be created.
-  # Then the score would be baseline (0) + (1 * data$val_a_centered) + (2 * data$val_b_logged).
-  # If these are NULL/NA, score would be 0 or NA.
-  # If it correctly uses "transform_test_model", the result is 9.
-  expect_equal(actual_value, expected_value, tolerance = 1e-7,
-               info = "This test checks if apply_transformations correctly uses the model_name passed to rydra_calculate. It might fail if apply_transformations hardcodes 'plgf_model'.")
-})
-
-# Add the new test file to tests/testthat.R if it's not automatically picked up.
-# Typically, testthat runs all files matching `test-*.R` in this directory.
-# Make sure basic_transformations functions are exported by Rydra package. (They are)
-# Make sure to run devtools::load_all() or install the package before testing.
-
-test_that("Using a transformation function not in the list fails as expected", {
-  temp_config_text <- '
+  test_that("Using a transformation function not in the list fails as expected", {
+    temp_config_text <- '
 model_name: "missing_func_test"
 centering: {} # No centering needed for this test
 missing_func_test:
@@ -224,20 +223,21 @@ missing_func_test:
   factors: []
   output_transformation: "result"
 '
-  temp_config_file <- tempfile(fileext = ".yaml")
-  writeLines(temp_config_text, temp_config_file)
-  on.exit(unlink(temp_config_file))
+    temp_config_file <- tempfile(fileext = ".yaml")
+    writeLines(temp_config_text, temp_config_file)
+    on.exit(unlink(temp_config_file))
 
-  input_data <- list(val = 5)
+    input_data <- list(val = 5)
 
-  # Calling with default transformations (which don't include 'a_truly_missing_function')
-  expect_warning(
-    rydra_calculate(
-      config_path = temp_config_file,
-      data = input_data,
-      model_name = "missing_func_test"
-      # transformations = .default_rydra_transformations (implicit)
-    ),
-    regexp = "Error evaluating transformation 'transformed_val'"
-  )
+    # Calling with default transformations (which don't include 'a_truly_missing_function')
+    expect_warning(
+      rydra_calculate(
+        config_path = temp_config_file,
+        data = input_data,
+        model_name = "missing_func_test"
+        # transformations = .default_rydra_transformations (implicit)
+      ),
+      regexp = "Error evaluating transformation 'transformed_val'"
+    )
+  })
 })


### PR DESCRIPTION
Replaced all instances of the deprecated `context()` function with the current `test_that()` function in the test suite. This aligns the codebase with testthat 3rd edition practices.